### PR TITLE
BUG Fix: Only ever deploy one instance of blog contract for a user

### DIFF
--- a/hardhat/contracts/BlogFactory.sol
+++ b/hardhat/contracts/BlogFactory.sol
@@ -21,6 +21,10 @@ contract BlogFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
     function createBlog(address _blogOwner) public payable {
+        require(
+            address(deployedBlogs[_blogOwner]) == address(0),
+            "Blog Contract already deployed for user"
+        );
         Blog blog = new Blog();
         deployedBlogs[_blogOwner] = blog;
     }


### PR DESCRIPTION
I've added a `require` statement which prevents from creating multiple instances of Blog contract for a user.